### PR TITLE
API.AI Richtext handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ wp-content/plugins/hello.php
 
 /node_modules/
 /.sass-cache/
+
+.idea/

--- a/classes/class-wp-chatbot-apiai-request.php
+++ b/classes/class-wp-chatbot-apiai-request.php
@@ -6,7 +6,7 @@ class WP_Chatbot_ApiAi_Request extends WP_Chatbot_Request {
 
 		$this->options = get_option( 'wp-chatbot-options-apiai' );
 
-	    $this->options['response-jsonpath'] = '$.result.fulfillment.messages[*]';
+	    $this->options['response-jsonpath'] = '$.result.fulfillment.messages[?(@["platform"] == null)]';
 
     $this->url = 'https://api.api.ai/v1/query';
     $this->method = 'GET';

--- a/classes/class-wp-chatbot-apiai-request.php
+++ b/classes/class-wp-chatbot-apiai-request.php
@@ -6,8 +6,7 @@ class WP_Chatbot_ApiAi_Request extends WP_Chatbot_Request {
 
 		$this->options = get_option( 'wp-chatbot-options-apiai' );
 
-
-		$this->options['response-jsonpath'] = '$.result.fulfillment.messages[*].speech';
+	    $this->options['response-jsonpath'] = '$.result.fulfillment.messages[*]';
 
     $this->url = 'https://api.api.ai/v1/query';
     $this->method = 'GET';
@@ -23,6 +22,19 @@ class WP_Chatbot_ApiAi_Request extends WP_Chatbot_Request {
       'Authorization' => 'Bearer ' . ( isset( $this->options['client-token'] ) ? $this->options['client-token'] : '' )
     );
 
+  }
+	/**
+	* Add the messages to the response array
+	*
+	* @param $responses
+	*
+	* @return void
+	*/
+	protected function add_messages( $responses ) {
+		foreach ( $responses as $response ){
+			$message = WP_Chatbot_Rich_Message_Factory::create( $response );
+			$this->add_response( $message );
+		}
 	}
 
   /**

--- a/classes/class-wp-chatbot-request.php
+++ b/classes/class-wp-chatbot-request.php
@@ -246,7 +246,7 @@ class WP_Chatbot_Request {
 
 
 		$special_values = apply_filters( 'wp_chatbot_special_values', array(
-			'WP_CHATBOT_INPUT_MSG' => $message,
+			'WP_CHATBOT_INPUT_MSG' => utf8_decode($message),
 			'WP_CHATBOT_CONV' => $conv,
 			'WP_CHATBOT_USER' => $user
 		));

--- a/classes/class-wp-chatbot-request.php
+++ b/classes/class-wp-chatbot-request.php
@@ -181,6 +181,19 @@ class WP_Chatbot_Request {
 	}
 
 	/**
+	 * Add the messages to the response array
+	 *
+	 * @param $responses
+	 *
+	 * @return void
+	 */
+	protected function add_messages( $responses) {
+		foreach ( $responses as $response ){
+			$this->add_response( new WP_Chatbot_Message( $response ));
+		}
+	}
+
+	/**
 	 * Append a response
 	 *
 	 * @param array A response object
@@ -280,9 +293,7 @@ class WP_Chatbot_Request {
 
 			if( is_array( $bot_responses ) ) {
 
-				foreach ( $bot_responses as $bot_response ){
-					$this->add_response( new WP_Chatbot_Message( $bot_response ));
-				}
+				$this->add_messages( $bot_responses );
 			}
 		}
 

--- a/classes/messages/class-wp-chatbot-rich-message-factory.php
+++ b/classes/messages/class-wp-chatbot-rich-message-factory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Maniae
+ */
+
+if( ! class_exists( 'WP_Chatbot_Rich_Message_Factory' ) ):
+
+	class WP_Chatbot_Rich_Message_Factory {
+
+		/**
+		 * Array mapping api.ai types to the corresponding class
+		 * 0 for the Text response message type
+		 * 1 for the Card message type
+		 * 2 for the Quick replies message type
+		 * 3 for the Image message type
+		 * 4 for the Custom payload message type
+		 * See <a href="https://docs.api.ai/docs/query">https://docs.api.ai/docs/query</a>
+		 */
+		private static $map = array(
+				0 => 'WP_Chatbot_Rich_Message_Text',
+				// No implementation of Card message yet
+				2 => 'WP_Chatbot_Rich_Message_Quick_Replies',
+				3 => 'WP_Chatbot_Rich_Message_Image',
+				// No implementation of Custom Payload message yet
+		);
+
+		public static function create( $message ) {
+			$type = $message['type'];
+			$rich_message = new self::$map[ $type ]( $message );
+			return $rich_message;
+		}
+	}
+
+
+endif;
+
+?>

--- a/classes/messages/class-wp-chatbot-rich-message-factory.php
+++ b/classes/messages/class-wp-chatbot-rich-message-factory.php
@@ -13,7 +13,7 @@ if( ! class_exists( 'WP_Chatbot_Rich_Message_Factory' ) ):
 		 * 1 for the Card message type
 		 * 2 for the Quick replies message type
 		 * 3 for the Image message type
-		 * 4 for the Custom payload message type
+		 * 4 is the Custom Payload message type, inside which the other types are found
 		 * See <a href="https://docs.api.ai/docs/query">https://docs.api.ai/docs/query</a>
 		 */
 		private static $map = array(
@@ -21,11 +21,14 @@ if( ! class_exists( 'WP_Chatbot_Rich_Message_Factory' ) ):
 				// No implementation of Card message yet
 				2 => 'WP_Chatbot_Rich_Message_Quick_Replies',
 				3 => 'WP_Chatbot_Rich_Message_Image',
-				// No implementation of Custom Payload message yet
 		);
 
 		public static function create( $message ) {
-			$type = $message['type'];
+			$type = $message['type']; // 0 or 4
+			if ($type == 4) {
+					$message = $message['payload'];
+					$type = $message['type']; // 0, 1, 2, or 3
+			}
 			$rich_message = new self::$map[ $type ]( $message );
 			return $rich_message;
 		}

--- a/classes/messages/class-wp-chatbot-rich-message-image.php
+++ b/classes/messages/class-wp-chatbot-rich-message-image.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Maniae
+ */
+
+if( ! class_exists( 'WP_Chatbot_Rich_Message_Image' ) ):
+
+	class WP_Chatbot_Rich_Message_Image implements WP_Chatbot_Rich_Message {
+
+		/**
+		 * Type of message
+		 */
+		public $type;
+
+		/**
+		 * The image url
+		 */
+		public $imageUrl;
+
+
+		public function __construct( $message ){
+			$this->type = 'image';
+			$this->imageUrl = $message['imageUrl'];
+		}
+
+		public function get_contents(){
+			return get_object_vars( $this );
+		}
+	}
+
+
+endif;
+
+?>

--- a/classes/messages/class-wp-chatbot-rich-message-quick-replies.php
+++ b/classes/messages/class-wp-chatbot-rich-message-quick-replies.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Maniae
+ */
+
+if( ! class_exists( 'WP_Chatbot_Rich_Message_Quick_Replies' ) ):
+
+	class WP_Chatbot_Rich_Message_Quick_Replies implements WP_Chatbot_Rich_Message {
+
+		/**
+		 * Type of message
+		 */
+		public $type;
+
+		/**
+		 * The message text
+		 */
+		public $title;
+
+		/**
+		 * The array of strings corresponding to quick replies
+		 */
+		public $replies;
+
+		public function __construct( $message ){
+			$this->type = 'quickReplies';
+			$this->title = $message['title'];
+			$this->replies = $message['replies'];
+		}
+
+		public function get_contents(){
+			return get_object_vars( $this );
+		}
+	}
+
+
+endif;
+
+?>

--- a/classes/messages/class-wp-chatbot-rich-message-text.php
+++ b/classes/messages/class-wp-chatbot-rich-message-text.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @author Maniae
+ */
+
+if( ! class_exists( 'WP_Chatbot_Rich_Message_Text' ) ):
+
+	class WP_Chatbot_Rich_Message_Text implements WP_Chatbot_Rich_Message {
+
+		/**
+		 * Type of message
+		 */
+		public $type;
+
+		/**
+		 * The message text
+		 */
+		public $speech;
+
+		public function __construct( $message ){
+			$this->type = 'textResponse';
+			$this->speech = $message['speech'];
+		}
+
+		public function get_contents(){
+			return get_object_vars( $this );
+		}
+	}
+
+endif;
+
+?>

--- a/classes/messages/wp-chatbot-rich-message.php
+++ b/classes/messages/wp-chatbot-rich-message.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @author Maniae
+ */
+
+interface WP_Chatbot_Rich_Message {
+	public function get_contents();
+}

--- a/css/wp-chatbot-pub.css
+++ b/css/wp-chatbot-pub.css
@@ -427,3 +427,26 @@
 #chatbot-launcher-icon:hover {
   box-shadow: 0 0 30px rgba(0, 0, 0, 0.4);
 }
+.chatbot-richText-wrapper {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 1px 50px;
+  text-align: center;
+}
+.chatbot-quickReply-wrapper {
+  display: inline-block;
+  min-width: 20px;
+  margin: 2px 4px;
+  border: 1px #007acc solid;
+  border-radius: 25px;
+  background: white;
+  cursor: pointer;
+  padding: 0 12px;
+}
+
+.chatbot-quickReply {
+  line-height: 26px;
+  font-size: 13px;
+  color: #007acc;
+}
+

--- a/wp-chatbot.php
+++ b/wp-chatbot.php
@@ -30,6 +30,14 @@ require_once plugin_dir_path( __FILE__ ) . 'classes/base/class-wp-chatbot-base.p
 require_once plugin_dir_path( __FILE__ ) . 'classes/base/class-wp-chatbot-admin-base.php';
 require_once plugin_dir_path( __FILE__ ) . 'classes/base/class-wp-chatbot-message.php';
 
+require_once plugin_dir_path( __FILE__ ) . 'classes/messages/class-wp-chatbot-rich-message-factory.php';
+require_once plugin_dir_path( __FILE__ ) . 'classes/messages/wp-chatbot-rich-message.php';
+require_once plugin_dir_path( __FILE__ ) . 'classes/messages/class-wp-chatbot-rich-message-text.php';
+require_once plugin_dir_path( __FILE__ ) . 'classes/messages/class-wp-chatbot-rich-message-image.php';
+require_once plugin_dir_path( __FILE__ ) . 'classes/messages/class-wp-chatbot-rich-message-quick-replies.php';
+
+
+
 
 /**
  * The core plugin class.


### PR DESCRIPTION
Implementation of Richtext in the plugin for api.ai. 
From: https://api.ai/docs/reference/agent/query

- Add your payload in the api.ai console:
![capture d ecran 2017-07-06 a 15 22 14](https://user-images.githubusercontent.com/16370446/27912985-f8a60bd8-625e-11e7-83b7-6281e4958ac3.png)

- api.ai will generate a richtext of the following format:
![capture d ecran 2017-07-06 a 15 23 56](https://user-images.githubusercontent.com/16370446/27913067-2e1d5a96-625f-11e7-8eac-c1e0c10669ed.png)
(See the link below)

- The richtext is printed inside the conversation, outside the message wrapper for quick replies:
![capture d ecran 2017-07-06 a 15 18 06](https://user-images.githubusercontent.com/16370446/27913111-5add0216-625f-11e7-885b-037361d79b72.png)
![capture d ecran 2017-07-06 a 15 18 55](https://user-images.githubusercontent.com/16370446/27913138-6ebc13c6-625f-11e7-8a2a-f9aadcf30e5e.png)

- Clicking on a button will send it to the bot:

![capture d ecran 2017-07-06 a 15 28 36](https://user-images.githubusercontent.com/16370446/27913258-d4a267bc-625f-11e7-853d-46fbd42b4247.png)

- Images are also supported, card are not:

![capture d ecran 2017-07-06 a 15 34 20](https://user-images.githubusercontent.com/16370446/27913530-b522329a-6260-11e7-823d-c9e2da063014.png)

If using webhook, you should send to the plugin a response of the following format:

```
    {
      "speech": "",
      "messages": [
        {
          "type": 0,
          "speech": "Here it is:"
        },
        {
          "type": 4,
          "payload": {
            "type": 3,
            "imageUrl": "https://assets-cdn.github.com/images/modules/open_graph/github-octocat.png"
          }
        }
      ]
    }
```
You can actually use it to send richtext from another platform than api.ai, but it follows api.ai standards.

Btw the code used to send the message when clicking on a button is a little hacky (change the input value and perform a click()) because I didn't want to change the scope of the already implemented functions.