### PR TITLE
Quick Replies & encoding bug fixes

### DIFF
--- a/classes/class-wp-chatbot-request.php
+++ b/classes/class-wp-chatbot-request.php
@@ -246,7 +246,7 @@ class WP_Chatbot_Request {
 
 
 		$special_values = apply_filters( 'wp_chatbot_special_values', array(
-			'WP_CHATBOT_INPUT_MSG' => utf8_decode($message),
+			'WP_CHATBOT_INPUT_MSG' => $message,
 			'WP_CHATBOT_CONV' => $conv,
 			'WP_CHATBOT_USER' => $user
 		));

--- a/js/wp-chatbot-pub.js
+++ b/js/wp-chatbot-pub.js
@@ -135,12 +135,17 @@ var WPChatbotRichParser = function() {
         var html = '<div class="chatbot-richText-wrapper">';
         replies.forEach(function (reply) {
             html += '<div class="chatbot-quickReply-wrapper animated fadein" onclick="' +
-                'document.getElementById(\'input\').value = \'' + reply + '\';' + // set the input value with the button value
+                'document.getElementById(\'input\').value = \'' + escapeQuotes(reply) + '\';' + // set the input value with the button value
                 'document.getElementById(\'send\').click()"><span class="chatbot-quickReply">' // send the message
                 + reply +'</span></div>';
         });
         return html + '</div>'
     };
+
+    function escapeQuotes(text) {
+        return text.replace(/'/g, "\\&#39;")
+            .replace(/"/, '\\&quot;')
+    }
     return WPChatbotRichParser
 
 }();


### PR DESCRIPTION
Hi !
I'm afraid my last commits brought 2 minor issues:

- A few weeks ago, api.ai encoding suddenly didn't receive special characters properly, I used the `utf8_decode` to send them and fix it, as it seemed they would not come back on this.
Well, they did fix the issue without providing information and/or a changelog, that means that the function `utf8_decode` now causes the special characters to be poorly encoded.

- Quotes and single quotes in quick replies were not escaped

Here is the fix.